### PR TITLE
Add the option to use local CSS and JavaScript minifiers instead of web services

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ This simply minifies and concatenate everything of js and css.
 
     $ ./js-css-minify.sh
 
+By default, it uses https://javascript-minifier.com/ and https;//cssminifier.com/ web services, but the minifier tools can be changed in the configuration file (/etc/myphotoshare/myphotoshare.conf), cssmin and jsmin are currently supported. More local tools can easily be added.
+
 ### Config your web server
 
 Be sure you have a web server installed (`apache2`, `nginx`, ...), with `php` and `php5-gd` modules installed and set.
@@ -294,6 +296,7 @@ Both the scanner and the webpage have a `make deploy` target, and the scanner ha
 * new option `use_geonames`, defaults to false, set it to true in order to create country/state/place albums
 * clustering of places with too many photos is done by the k-means algorithm, better than the previous one, which remains a "legacy"
 * new option `legacy_clustering_function`: if set to false (default), the k-means algorithm is used for clustering places with too many photos
+* Can use local CSS and JavaScript minifiers instead of web services.
 
 ### version 3.2 (January 7, 2018)
 

--- a/js-css-minify.sh
+++ b/js-css-minify.sh
@@ -11,6 +11,53 @@ MINIFY_CSS=${MINIFY_CSS:-web_service}
 
 unixseconds=$(date +%s)
 
+# Check that local minifiers are installed
+case $MINIFY_JS in
+	web_service)
+		curl https://javascript-minifier.com/ > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo "'curl' not installed or 'https://javascript-minifier.com/' down"
+			echo "Aborting..."
+			exit 1
+		fi
+	;;
+	jsmin2)
+		python2 -m jsmin > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo "'jsmin' for Python2 is not installed. Look for package 'python-jsmin' or 'https://github.com/tikitu/jsmin'"
+			echo "Aborting..."
+			exit 1
+		fi
+	;;
+	jsmin3)
+		python3 -m jsmin > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo "'jsmin' for Python3 is not installed. Look for package 'python3-jsmin' or 'https://github.com/tikitu/jsmin'"
+			echo "Aborting..."
+			exit 1
+		fi
+	;;
+esac
+
+case $MINIFY_CSS in
+	web_service)
+		curl https://cssminifier.com/ > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo "'curl' not installed or 'https://cssminifier.com/' down"
+			echo "Aborting..."
+			exit 1
+		fi
+	;;
+	cssmin)
+		cssmin -h > /dev/null 2>&1
+		if [ $? -ne 0 ]; then
+			echo "'cssmin' is not installed. Look for package 'cssmin' or 'https://github.com/zacharyvoase/cssmin'"
+			echo "Aborting..."
+			exit 1
+		fi
+	;;
+esac
+
 # minify all .js-files
 cd web/js
 echo

--- a/js-css-minify.sh
+++ b/js-css-minify.sh
@@ -1,18 +1,42 @@
 #!/bin/bash
 
+# Parse which minifiers to use from configuration file
+CONF=/etc/myphotoshare/myphotoshare.conf
+
+MINIFY_JS="$(sed -nr 's/^\s*minify_js\s*=\s*(\w+)\s*.*$/\1/p' $CONF)"
+MINIFY_JS=${MINIFY_JS:-web_service}
+
+MINIFY_CSS="$(sed -nr 's/^\s*minify_css\s*=\s*(\w+)\s*.*$/\1/p' $CONF)"
+MINIFY_CSS=${MINIFY_CSS:-web_service}
+
+unixseconds=$(date +%s)
+
 # minify all .js-files
 cd web/js
-unixseconds=$(date +%s)
 echo
 echo == Minifying js files in js directory ==
 echo
 rm -f *.min.js
-ls -1 *.js|grep -Ev "min.js$" | while read jsfile; do
+ls -1 *.js | grep -Ev "min.js$" | while read jsfile; do
 	newfile="${jsfile%.*}.min.js"
-
-	echo
 	echo "minifying $jsfile"
-	curl -X POST -s --data-urlencode "input@$jsfile" https://javascript-minifier.com/raw > $newfile
+	case $MINIFY_JS in
+		web_service)
+			curl -X POST -s --data-urlencode "input@$jsfile" https://javascript-minifier.com/raw > $newfile
+		;;
+
+		jsmin2)
+			python2 -m jsmin $jsfile > $newfile
+		;;
+
+		jsmin3)
+			python3 -m jsmin $jsfile > $newfile
+		;;
+
+		*)
+			echo "Unsupported Javascript minifier: $MINIFY_JS. Check option 'minify_js' in '$CONF'"
+			echo "Doing nothing on file $jsfile"
+	esac
 done
 
 # merge all into one single file
@@ -26,20 +50,27 @@ echo
 echo == Minifying css files in css directory ==
 echo
 rm -f *.min.css
-ls -1 *.css|grep -Ev "min.css$" | while read cssfile; do
+ls -1 *.css | grep -Ev "min.css$" | while read cssfile; do
 	newfile="${cssfile%.*}.min.css"
 	echo "minifying $cssfile"
-	curl -X POST -s --data-urlencode "input@$cssfile" https://cssminifier.com/raw > $newfile
-	#~ if [ $? -ne 0 ]; then
-		#~ echo
-		#~ echo "*****************"
-		#~ echo "error minifying $cssfile"
-		#~ echo "stopping"
-		#~ echo "*****************"
-		#~ break
-	#~ fi
+	case $MINIFY_CSS in
+		web_service)
+			curl -X POST -s --data-urlencode "input@$cssfile" https://cssminifier.com/raw > $newfile
+		;;
+
+		cssmin)
+			cssmin < $cssfile > $newfile
+		;;
+
+		*)
+			echo "Unsupported CSS minifier: $MINIFY_CSS. Check option 'minify_css' in '$CONF'"
+			echo "Doing nothing on file $cssfile"
+	esac
 done
 
 # merge all into one single file
 rm -f styles.min.css
 cat *.min.css > styles.min.css
+
+echo
+echo "Completed in $((`date +%s` - $unixseconds)) s."

--- a/myphotoshare.conf.defaults
+++ b/myphotoshare.conf.defaults
@@ -20,6 +20,25 @@
 debug_css = false
 debug_js = false
 
+
+###########################################################
+# minify
+###########################################################
+
+# CSS minifier
+# permitted values:
+#    web_service : https://cssminifier.com/ (Default)
+#    cssmin : cssmin (https://github.com/zacharyvoase/cssmin)
+minify_css = web_service
+
+# JavaScript minifier
+# permitted values:
+#    web_service : https://javascript-minifier.com/ (Default)
+#    jsmin2 : python-jsmin (https://github.com/tikitu/jsmin)
+#    jsmin3 : python3-jsmin (https://github.com/tikitu/jsmin)
+minify_js = web_service
+
+
 ###########################################################
 # scanner option
 ###########################################################


### PR DESCRIPTION
Issue https://github.com/paolobenve/myphotoshare/issues/60

This version changes the `js-css-minify.sh` script to let the user decide which minifiers to use. I've added the new options `minify_css` and `minify_js` in the `myphotoshare.conf.defaults` file where the user can select to use the default web services (options value `web_service`) or the name of a local minifier. For the moment, only `cssmin`, `jsmin2` and `jsmin3` Python scripts that are available as Debian/Ubuntu packages are supported, but new ones can easily be added in the `js-css-minify.sh` script.
The resulting minified files from using `cssmin`and `jsmin3` are larger than when using the web services, but the minifying operation takes less time and is less prone to timeouts.