### PR TITLE
Issue #65: Video don't play with FireFox. Don't change media when it's not a photo.

### DIFF
--- a/web/js/012-display.js
+++ b/web/js/012-display.js
@@ -1696,7 +1696,7 @@ $(document).ready(function() {
 					}
 				})
 				.on('click', function(ev) {
-					if(ev.which == 1 && ! ev.shiftKey && ! ev.ctrlKey && ! ev.altKey) {
+					if(ev.which == 1 && ! ev.shiftKey && ! ev.ctrlKey && ! ev.altKey && currentMedia.mediaType == "photo") {
 						swipeLeft(nextLink);
 						return false;
 					} else


### PR DESCRIPTION
Solves issue #65.

Tested with FireFox and Chromium.
One of the reasons why it's more visible on FireFox is that you can start a video when you click on the player image, while on Chromium you have to use the play button in the control bar.
Probably could be a bit nicer by changing the mouse icon when over the HTML5 player, but at least it works correctly.