### PR TITLE
User-defined metadata filename can be chosen instead of 'album.ini'

### DIFF
--- a/bin/make_album_ini.sh
+++ b/bin/make_album_ini.sh
@@ -7,12 +7,42 @@
 # jpg,jpeg,JPG,JPEG,mp4,avi,MP4,AVI
 
 
+print_usage()
+{
+	echo "Usage: $0 [-i METADATA_FILENAME] FOLDER"
+	echo "Create template of 'album.ini' file in 'FOLDER' based on its media content."
+	echo "When the file 'album.ini' already exists in 'FOLDER', new media are added to the file."
+	echo
+	echo "Options:"
+	echo "  -i: Define the filename used to store user-defined metadata instead of default 'album.ini'"
+	echo
+	echo "Example:"
+	echo "   $0 -i .album.ini ~/Pictures/vacations"
+	echo "   Create hidden file '.album.ini' in '~/Pictures/vacations"
+}
+
+
+# Process options
+ALBUM_INI="album.ini"
+
+while getopts "i:" option; do
+	case $option in
+		i)
+			ALBUM_INI="$OPTARG"
+		;;
+		\?)
+			print_usage
+			exit 1
+		;;
+	esac
+done
+shift $((OPTIND-1))
+
+# Process parameters
 DIR=${1%/}
 
 if [ -z "$DIR" ]; then
-	echo "$0 FOLDER"
-	echo "Create template of 'album.ini' file in 'FOLDER' based on its media content."
-	echo "When the file 'album.ini' already exists in 'FOLDER', new media are added to the file."
+	print_usage
 	exit 1
 elif [ ! -d "$DIR" ]; then
 	( >&2 echo "Argument must be a directory containing media." )
@@ -20,46 +50,46 @@ elif [ ! -d "$DIR" ]; then
 fi
 
 
-if [ ! -f "$DIR/album.ini" ]; then
-	echo "# User defined metadata for MyPhotoShare" > "$DIR/album.ini"
-	echo "########################################" >> "$DIR/album.ini"
-	echo "# Possible metadata:" >> "$DIR/album.ini"
-	echo "# - title: To give a title to the photo, video or album." >> "$DIR/album.ini"
-	echo "# - description: A long description of the media." >> "$DIR/album.ini"
-	echo "# - tags: A comma separated list of key words." >> "$DIR/album.ini"
-	echo "# - date: The date the photo was taken, in the format YYYY-MM-DD." >> "$DIR/album.ini"
-	echo "# - latitude: The latitude of the media, for instance if the media was not geotagged when captured." >> "$DIR/album.ini"
-	echo "# - longitude: The longitude of the capture of media." >> "$DIR/album.ini"
-	echo "# - country_name: The name of the country where the photo was shot." >> "$DIR/album.ini"
-	echo "# - region_name: The name of the region." >> "$DIR/album.ini"
-	echo "# - place_name: The name of the city or town to be displayed." >> "$DIR/album.ini"
-	echo >> "$DIR/album.ini"
-	echo >> "$DIR/album.ini"
-	echo "#[DEFAULT]" >> "$DIR/album.ini"
-	echo "#tags = " >> "$DIR/album.ini"
-	echo "#date = " >> "$DIR/album.ini"
-	echo "#latitude = " >> "$DIR/album.ini"
-	echo "#longitude = " >> "$DIR/album.ini"
-	echo "#place_name = " >> "$DIR/album.ini"
-	echo "#region_name = " >> "$DIR/album.ini"
-	echo "#country_name = " >> "$DIR/album.ini"
-	echo >> "$DIR/album.ini"
-	echo >> "$DIR/album.ini"
+if [ ! -f "$DIR/$ALBUM_INI" ]; then
+	echo "# User defined metadata for MyPhotoShare" > "$DIR/$ALBUM_INI"
+	echo "########################################" >> "$DIR/$ALBUM_INI"
+	echo "# Possible metadata:" >> "$DIR/$ALBUM_INI"
+	echo "# - title: To give a title to the photo, video or album." >> "$DIR/$ALBUM_INI"
+	echo "# - description: A long description of the media." >> "$DIR/$ALBUM_INI"
+	echo "# - tags: A comma separated list of key words." >> "$DIR/$ALBUM_INI"
+	echo "# - date: The date the photo was taken, in the format YYYY-MM-DD." >> "$DIR/$ALBUM_INI"
+	echo "# - latitude: The latitude of the media, for instance if the media was not geotagged when captured." >> "$DIR/$ALBUM_INI"
+	echo "# - longitude: The longitude of the capture of media." >> "$DIR/$ALBUM_INI"
+	echo "# - country_name: The name of the country where the photo was shot." >> "$DIR/$ALBUM_INI"
+	echo "# - region_name: The name of the region." >> "$DIR/$ALBUM_INI"
+	echo "# - place_name: The name of the city or town to be displayed." >> "$DIR/$ALBUM_INI"
+	echo >> "$DIR/$ALBUM_INI"
+	echo >> "$DIR/$ALBUM_INI"
+	echo "#[DEFAULT]" >> "$DIR/$ALBUM_INI"
+	echo "#tags = " >> "$DIR/$ALBUM_INI"
+	echo "#date = " >> "$DIR/$ALBUM_INI"
+	echo "#latitude = " >> "$DIR/$ALBUM_INI"
+	echo "#longitude = " >> "$DIR/$ALBUM_INI"
+	echo "#place_name = " >> "$DIR/$ALBUM_INI"
+	echo "#region_name = " >> "$DIR/$ALBUM_INI"
+	echo "#country_name = " >> "$DIR/$ALBUM_INI"
+	echo >> "$DIR/$ALBUM_INI"
+	echo >> "$DIR/$ALBUM_INI"
 fi
 
 # Count the number of media added
 SECTION_COUNT=0
 
 # The [album] section
-SECTION_EXISTS=$(grep -c "\[album\]" "$DIR/album.ini")
+SECTION_EXISTS=$(grep -c "\[album\]" "$DIR/$ALBUM_INI")
 if [ $SECTION_EXISTS -eq 0 ]; then
 	TITLE=${DIR##*/}
-	echo "[album]" >> "$DIR/album.ini"
-	echo "#title = $TITLE" >> "$DIR/album.ini"
-	echo "#description = " >> "$DIR/album.ini"
-	echo "#tags = " >> "$DIR/album.ini"
-	echo >> "$DIR/album.ini"
-	echo >> "$DIR/album.ini"
+	echo "[album]" >> "$DIR/$ALBUM_INI"
+	echo "#title = $TITLE" >> "$DIR/$ALBUM_INI"
+	echo "#description = " >> "$DIR/$ALBUM_INI"
+	echo "#tags = " >> "$DIR/$ALBUM_INI"
+	echo >> "$DIR/$ALBUM_INI"
+	echo >> "$DIR/$ALBUM_INI"
 	((SECTION_COUNT+=1))
 fi
 
@@ -69,21 +99,21 @@ IFS=$(echo -en "\n\b")
 for media in $(ls "$DIR"/*.{jpg,jpeg,JPG,JPEG,mp4,avi,MP4,AVI} 2> /dev/null); do
 	SECTION=${media##*/}
 	TITLE=${SECTION%.*}
-	SECTION_EXISTS=$(grep -c "\[$SECTION\]" "$DIR/album.ini")
+	SECTION_EXISTS=$(grep -c "\[$SECTION\]" "$DIR/$ALBUM_INI")
 	if [ $SECTION_EXISTS -eq 0 ]; then
-		echo "[$SECTION]" >> "$DIR/album.ini"
-		echo "#title = $TITLE" >> "$DIR/album.ini"
-		echo "#description = " >> "$DIR/album.ini"
-		echo "#tags = " >> "$DIR/album.ini"
-		echo "#latitude = " >> "$DIR/album.ini"
-		echo "#longitude = " >> "$DIR/album.ini"
-		echo >> "$DIR/album.ini"
-		echo >> "$DIR/album.ini"
+		echo "[$SECTION]" >> "$DIR/$ALBUM_INI"
+		echo "#title = $TITLE" >> "$DIR/$ALBUM_INI"
+		echo "#description = " >> "$DIR/$ALBUM_INI"
+		echo "#tags = " >> "$DIR/$ALBUM_INI"
+		echo "#latitude = " >> "$DIR/$ALBUM_INI"
+		echo "#longitude = " >> "$DIR/$ALBUM_INI"
+		echo >> "$DIR/$ALBUM_INI"
+		echo >> "$DIR/$ALBUM_INI"
 		((SECTION_COUNT+=1))
 	fi
 done
 IFS=$SAVEIFS
 
 # Print number of media added in 'album.ini'
-echo "$SECTION_COUNT media added to '$DIR/album.ini'."
+echo "$SECTION_COUNT media added to '$DIR/$ALBUM_INI'."
 

--- a/myphotoshare.conf.defaults
+++ b/myphotoshare.conf.defaults
@@ -88,11 +88,14 @@ js_minifier = jsmin3
 
 
 ###########################################################
-# scanner option
+# scanner options
 ###########################################################
 
 # cache subfolder: where the album composite images will be saved
 cache_album_subdir = cache_album
+
+# Filename where user-defined metadata is stored in albums
+metadata_filename = album.ini
 
 # How many processors shouldn't be used when converting media?
 respected_processors = 1

--- a/scanner/PhotoAlbum.py
+++ b/scanner/PhotoAlbum.py
@@ -214,9 +214,9 @@ class Album(object):
 		"""
 		self.album_ini = configparser.ConfigParser(allow_no_value=True)
 		message("reading album.ini...", "", 5)
-		self.album_ini.read(os.path.join(self.absolute_path, "album.ini"))
+		self.album_ini.read(os.path.join(self.absolute_path, Options.config['metadata_filename']))
 		next_level()
-		message("album.ini read", os.path.join(self.absolute_path, "album.ini"), 5)
+		message("album.ini read", os.path.join(self.absolute_path, Options.config['metadata_filename']), 5)
 		back_level()
 
 		Metadata.set_metadata_from_album_ini("album", self._attributes, self.album_ini)
@@ -1799,14 +1799,14 @@ class Metadata(object):
 			try:
 				attributes["metadata"]["dateTime"] = datetime.strptime(album_ini.get(name, "date"), "%Y-%m-%d")
 			except ValueError:
-				message("ERROR", "Incorrect date in [" + name + "] in 'album.ini'", 1)
+				message("ERROR", "Incorrect date in [" + name + "] in '" + Options.config['metadata_filename'] + "'", 1)
 			except NoOptionError:
 				pass
 		elif "date" in album_ini.defaults():
 			try:
 				attributes["metadata"]["dateTime"] = datetime.strptime(album_ini.defaults()["date"], "%Y-%m-%d")
 			except ValueError:
-				message("ERROR", "Incorrect date in [DEFAULT] in 'album.ini'", 1)
+				message("ERROR", "Incorrect date in [DEFAULT] in '" + Options.config['metadata_filename'] + "'", 1)
 
 		# Latitude and longitude
 		gps_latitude = None
@@ -1818,7 +1818,7 @@ class Metadata(object):
 				gps_latitude = Metadata.create_gps_struct(abs(album_ini.getfloat(name, "latitude")))
 				gps_latitude_ref = "N" if album_ini.getfloat(name, "latitude") > 0.0 else "S"
 			except ValueError:
-				message("ERROR", "Incorrect latitude in [" + name + "] in 'album.ini'", 1)
+				message("ERROR", "Incorrect latitude in [" + name + "] in '" + Options.config['metadata_filename'] + "'", 1)
 			except NoOptionError:
 				pass
 		elif "latitude" in album_ini.defaults():
@@ -1826,13 +1826,13 @@ class Metadata(object):
 				gps_latitude = Metadata.create_gps_struct(abs(float(album_ini.defaults()["latitude"])))
 				gps_latitude_ref = "N" if float(album_ini.defaults()["latitude"]) > 0.0 else "S"
 			except ValueError:
-				message("ERROR", "Incorrect latitude in [" + name + "] in 'album.ini'", 1)
+				message("ERROR", "Incorrect latitude in [" + name + "] in '" + Options.config['metadata_filename'] + "'", 1)
 		if album_ini.has_section(name):
 			try:
 				gps_longitude = Metadata.create_gps_struct(abs(album_ini.getfloat(name, "longitude")))
 				gps_longitude_ref = "E" if album_ini.getfloat(name, "longitude") > 0.0 else "W"
 			except ValueError:
-				message("ERROR", "Incorrect longitude in [" + name + "] in 'album.ini'", 1)
+				message("ERROR", "Incorrect longitude in [" + name + "] in '" + Options.config['metadata_filename'] + "'", 1)
 			except NoOptionError:
 				pass
 		elif "longitude" in album_ini.defaults():
@@ -1840,7 +1840,7 @@ class Metadata(object):
 				gps_longitude = Metadata.create_gps_struct(abs(float(album_ini.defaults()["longitude"])))
 				gps_longitude_ref = "E" if float(album_ini.defaults()["longitude"]) > 0.0 else "W"
 			except ValueError:
-				message("ERROR", "Incorrect longitude in [" + name + "] in 'album.ini'", 1)
+				message("ERROR", "Incorrect longitude in [" + name + "] in '" + Options.config['metadata_filename'] + "'", 1)
 
 		if gps_latitude and gps_latitude_ref and gps_longitude and gps_longitude_ref:
 			attributes["metadata"]["latitude"] = Metadata.convert_to_degrees_decimal(gps_latitude, gps_latitude_ref)

--- a/scanner/TreeWalker.py
+++ b/scanner/TreeWalker.py
@@ -12,9 +12,8 @@ import time
 import random
 import math
 import unicodedata
-from datetime import datetime
-import unicodedata
 import unidecode
+from datetime import datetime
 
 from PIL import Image
 
@@ -672,7 +671,7 @@ class TreeWalker:
 		if json_file_exists:
 			json_file_mtime = file_mtime(json_file)
 		json_file_OK = False
-		album_ini_file = os.path.join(absolute_path, 'album.ini')
+		album_ini_file = os.path.join(absolute_path, Options.config['metadata_filename'])
 		album_ini_OK = True
 		cached_album = None
 		json_message = json_file + " (path: " + os.path.basename(absolute_path) + ")"
@@ -778,7 +777,7 @@ class TreeWalker:
 				back_level()
 				continue
 
-			if entry[0] == '.' or entry == "album.ini":
+			if entry[0] == '.' or entry == Options.config['metadata_filename']:
 				# skip hidden files and directories, or user's metadata file 'album.ini'
 				continue
 

--- a/scanner/Utilities.py
+++ b/scanner/Utilities.py
@@ -162,7 +162,7 @@ def report_times(final):
 		num_media_in_tree
 	except NameError:
 		# calculate the number of media in the album tree: it will be used in order to guess the execution time
-		special_files = [Options.config['exclude_tree_marker'], Options.config['exclude_files_marker'], 'album.ini']
+		special_files = [Options.config['exclude_tree_marker'], Options.config['exclude_files_marker'], Options.config['metadata_filename']]
 		num_media_in_tree = sum([len([file for file in files if file[:1] != '.' and file not in special_files]) for dirpath, dirs, files in os.walk(Options.config['album_path']) if dirpath.find('/.') == -1])
 
 	try:


### PR DESCRIPTION
Small change to support user-defined metadata files, as detailed in #91.
For the moment, only `make_album_ini.sh` has been changed. I'll adapt `scanner` to use that filename tomorrow.